### PR TITLE
Url method returns signed url by default

### DIFF
--- a/lib/shrine/storage/google_cloud_storage.rb
+++ b/lib/shrine/storage/google_cloud_storage.rb
@@ -58,13 +58,13 @@ class Shrine
 
       # URL to the remote file, accepts options for customizing the URL
       def url(id, **options)
-        if options.key? :expires
+        if @default_acl == 'publicRead'
+          host = @host || "storage.googleapis.com/#{@bucket}"
+          "https://#{host}/#{object_name(id)}"
+        else
           signed_url = storage.signed_url(@bucket, object_name(id), options)
           signed_url.gsub!(/storage.googleapis.com\/#{@bucket}/, @host) if @host
           signed_url
-        else
-          host = @host || "storage.googleapis.com/#{@bucket}"
-          "https://#{host}/#{object_name(id)}"
         end
       end
 


### PR DESCRIPTION
 instead of passing expires when calling #{attribute}_url check for default_acl and generate signed url always, if default_acl is set to publicRead in initializer then public url will be printed.